### PR TITLE
feat: use signoutRedirect for per-tenant auth with end_session_endpoint

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -6,5 +6,6 @@ export default defineSchema({
     tokenIdentifier: v.string(),
     name: v.optional(v.string()),
     email: v.optional(v.string()),
+    phone: v.optional(v.string()),
   }).index("by_token", ["tokenIdentifier"]),
 });

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -21,7 +21,7 @@ export const updateCurrentUser = mutation({
     return await ctx.db.insert("users", {
       name: identity.name,
       email: identity.email,
-      phone: identity.phoneNumber as string | undefined,
+      phone: (identity.phoneNumber ?? identity["phone_number"]) as string | undefined,
       tokenIdentifier: identity.tokenIdentifier,
     });
   },

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -6,18 +6,13 @@ export const updateCurrentUser = mutation({
   handler: async (ctx) => {
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) {
-      throw new ConvexError({
-        code: "UNAUTHENTICATED",
-        message: "User not logged in",
-      });
+      throw new ConvexError({ code: "UNAUTHENTICATED", message: "User not logged in" });
     }
 
     // Check if we've already stored this identity before.
     const user = await ctx.db
       .query("users")
-      .withIndex("by_token", (q) =>
-        q.eq("tokenIdentifier", identity.tokenIdentifier),
-      )
+      .withIndex("by_token", (q) => q.eq("tokenIdentifier", identity.tokenIdentifier))
       .unique();
     if (user !== null) {
       return user._id;
@@ -26,6 +21,7 @@ export const updateCurrentUser = mutation({
     return await ctx.db.insert("users", {
       name: identity.name,
       email: identity.email,
+      phone: identity.phoneNumber as string | undefined,
       tokenIdentifier: identity.tokenIdentifier,
     });
   },
@@ -43,9 +39,7 @@ export const getCurrentUser = query({
     }
     const user = await ctx.db
       .query("users")
-      .withIndex("by_token", (q) =>
-        q.eq("tokenIdentifier", identity.tokenIdentifier),
-      )
+      .withIndex("by_token", (q) => q.eq("tokenIdentifier", identity.tokenIdentifier))
       .unique();
     return user;
   },

--- a/src/components/ui/signin.tsx
+++ b/src/components/ui/signin.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, useCallback, useEffect } from "react";
+import { forwardRef, useCallback, useEffect, useState } from "react";
 import { type VariantProps } from "class-variance-authority";
 import { Loader2, LogIn, LogOut } from "lucide-react";
 import { toast } from "sonner";
@@ -61,8 +61,21 @@ export const SignInButton = forwardRef<HTMLButtonElement, SignInButtonProps>(
     },
     ref,
   ) => {
-    const { isAuthenticated, signinRedirect, removeUser, isLoading, error } =
+    const { isAuthenticated, signinRedirect, signoutRedirect, removeUser, isLoading, error } =
       useAuth();
+
+    const [supportsEndSession, setSupportsEndSession] = useState(false);
+
+    useEffect(() => {
+      const authority = import.meta.env.VITE_HERCULES_OIDC_AUTHORITY;
+      if (!authority) return;
+      fetch(`${authority}/.well-known/openid-configuration`)
+        .then((res) => res.json())
+        .then((metadata) =>
+          setSupportsEndSession(!!metadata.end_session_endpoint),
+        )
+        .catch(() => setSupportsEndSession(false));
+    }, []);
 
     useEffect(() => {
       if (error) {
@@ -80,7 +93,11 @@ export const SignInButton = forwardRef<HTMLButtonElement, SignInButtonProps>(
 
         try {
           if (isAuthenticated) {
-            await removeUser();
+            if (supportsEndSession) {
+              await signoutRedirect();
+            } else {
+              await removeUser();
+            }
           } else {
             await signinRedirect();
           }
@@ -89,7 +106,7 @@ export const SignInButton = forwardRef<HTMLButtonElement, SignInButtonProps>(
           // Don't prevent the default here as the auth library handles errors
         }
       },
-      [isAuthenticated, removeUser, signinRedirect, onClick],
+      [isAuthenticated, removeUser, signoutRedirect, signinRedirect, supportsEndSession, onClick],
     );
 
     const isDisabled = disabled || isLoading;


### PR DESCRIPTION
Detects end_session_endpoint support from the OIDC discovery document at mount time. Per-tenant auth (*.auth.onhercules.app) gets proper RP-initiated logout via signoutRedirect, while legacy shared auth (hercules.app) continues using removeUser for instant sign-out.