### PR TITLE
fix: connect HMR WebSocket through preview proxy

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
     allowedHosts: true,
     hmr: {
       overlay: false,
+      clientPort: 443,
+      protocol: "wss",
     },
   },
   plugins: [react(), tailwindcss(), hercules()],


### PR DESCRIPTION
## What

Adds `clientPort: 443` and `protocol: "wss"` to the `server.hmr` block in `vite.config.ts` so the preview Hot Module Replacement WebSocket connects through the HTTPS proxy at `<id>.hercules-dev.com` (443/wss) instead of Vite's default `ws://<host>:5173`.

## Why

This is the root-cause fix for CUS-1083. The shipped template `hmr` block sets only `overlay: false`, so Vite's HMR client defaults to `ws://<host>:5173`, which fails behind the dev-machine preview proxy (mixed-content + port 5173 is not externally exposed; nginx upgrades 443 to the internal `127.0.0.1:5173`). New apps repeatedly throw `[vite] failed to connect to websocket`.

`vite.config.ts` is a protected file, so neither the user nor the in-app agent can fix it themselves. hercules.app#3086 adds a `fix-vite-hmr-client-port` codemod to patch existing apps; this PR fixes the source so newly created apps ship the correct block and never hit the bug.

The `managed-v1` variant has no `vite.config.ts` of its own, so it inherits this root config. Fixing this single file corrects both `main.tar.gz` and `managed-v1/main.tar.gz`.

## Coordination with the codemod

The codemod (hercules.app#3086) injects the identical `clientPort: 443` + `protocol: "wss"` and runs in `once` mode, so once this template fix ships it no-ops (`already_satisfied`) on new apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)