### PR TITLE
fix: add a root error boundary to prevent blank-screen crashes

### DIFF
--- a/.github/template-variants/managed-v1/src/App.tsx
+++ b/.github/template-variants/managed-v1/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Outlet, Route, Routes } from "react-router-dom";
+import { ErrorBoundary } from "./components/error-boundary.tsx";
 import { DefaultProviders } from "./components/providers/default.tsx";
 import { DeploymentEntryProvider } from "./components/providers/deployment-entry.tsx";
 import AuthCallback from "./pages/auth/Callback.tsx";
@@ -15,17 +16,19 @@ function ProtectedAppRoutes() {
 
 export default function App() {
   return (
-    <DefaultProviders>
-      <BrowserRouter>
-        <Routes>
-          <Route path="/auth/callback" element={<AuthCallback />} />
-          <Route element={<ProtectedAppRoutes />}>
-            <Route path="/" element={<Index />} />
-            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-            <Route path="*" element={<NotFound />} />
-          </Route>
-        </Routes>
-      </BrowserRouter>
-    </DefaultProviders>
+    <ErrorBoundary>
+      <DefaultProviders>
+        <BrowserRouter>
+          <Routes>
+            <Route path="/auth/callback" element={<AuthCallback />} />
+            <Route element={<ProtectedAppRoutes />}>
+              <Route path="/" element={<Index />} />
+              {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+              <Route path="*" element={<NotFound />} />
+            </Route>
+          </Routes>
+        </BrowserRouter>
+      </DefaultProviders>
+    </ErrorBoundary>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
+import { ErrorBoundary } from "./components/error-boundary.tsx";
 import { DefaultProviders } from "./components/providers/default.tsx";
 import AuthCallback from "./pages/auth/Callback.tsx";
 import Index from "./pages/Index.tsx";
@@ -6,15 +7,17 @@ import NotFound from "./pages/NotFound.tsx";
 
 export default function App() {
   return (
-    <DefaultProviders>
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          <Route path="/auth/callback" element={<AuthCallback />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
-    </DefaultProviders>
+    <ErrorBoundary>
+      <DefaultProviders>
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Index />} />
+            <Route path="/auth/callback" element={<AuthCallback />} />
+            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </BrowserRouter>
+      </DefaultProviders>
+    </ErrorBoundary>
   );
 }

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -1,0 +1,65 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { RefreshCwIcon } from "lucide-react";
+import { Button } from "@/components/ui/button.tsx";
+import {
+  ErrorState,
+  ErrorStateContent,
+  ErrorStateDescription,
+  ErrorStateHeader,
+  ErrorStateMedia,
+  ErrorStateTitle,
+} from "@/components/ui/error-state.tsx";
+
+type ErrorBoundaryProps = {
+  children: ReactNode;
+};
+
+type ErrorBoundaryState = {
+  error: Error | null;
+};
+
+// Without a boundary, any render-time throw (including a Convex `useQuery` that
+// errors mid auth-initialization) unmounts the whole tree to a blank screen.
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("Unhandled render error:", error, info.componentStack);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div className="flex min-h-screen items-center justify-center p-6">
+          <ErrorState>
+            <ErrorStateHeader>
+              <ErrorStateMedia variant="icon" />
+              <ErrorStateTitle>Something went wrong</ErrorStateTitle>
+              <ErrorStateDescription>
+                The page ran into an unexpected error. Reloading usually fixes
+                it.
+              </ErrorStateDescription>
+            </ErrorStateHeader>
+            <ErrorStateContent>
+              <Button onClick={() => window.location.reload()}>
+                <RefreshCwIcon />
+                Reload page
+              </Button>
+            </ErrorStateContent>
+          </ErrorState>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
https://linear.app/hercules-app/issue/CUS-1202/admin-panel-blank-screen

## Issue

Generated apps render a fully blank white screen on any uncaught render-time throw. In CUS-1202 the customer's `/admin` route intermittently blanks in the App Builder preview ("it works until it doesn't"), and diagnosing/fixing it burned multiple credit-consuming agent turns. This is the shared root cause behind a recurring class of "blank / white / black screen" escalations, not a one-off.

## Root cause

The template scaffold (`main.tsx` renders `<App/>`; `App.tsx` wraps `DefaultProviders` + routes) ships **no React error boundary anywhere**. When any component throws during render — notably a Convex `useQuery` that errors during the auth-initialization race — React unmounts the entire tree to a blank page with no recovery path. Every app generated from this template inherits the gap.

For the CUS-1202 app specifically, the admin layout renders a real UI for every auth state (skeleton while `AuthLoading`, a sign-in card while `Unauthenticated`, a "Not authorized" card for non-admins, the shell when authorized), so a *blank* screen cannot come from that component's own branches — it can only be an uncaught throw with nothing to catch it. The customer's in-app agent independently converged on the same conclusion and fixed it app-side by adding an error boundary; after that the dashboard rendered.

## What this changes

- Adds `src/components/error-boundary.tsx`: a class `ErrorBoundary` (`getDerivedStateFromError` + `componentDidCatch`) whose fallback renders the template's existing `ErrorState` UI plus a "Reload page" action, and logs the error to the console.
- Wraps the app in it, outside `DefaultProviders`, so even a provider-init throw is caught:
  - base template `src/App.tsx`
  - `managed-v1` access-control overlay `.github/template-variants/managed-v1/src/App.tsx` (it overrides `App.tsx`, so it needs its own wrap; it inherits the new component from the base)

An uncaught throw now shows a recoverable screen instead of a blank page. Apps that never throw are unaffected. The boundary does not swallow errors silently (console + visible recovery UI), so agent screenshot-verification and developer debugging improve rather than regress.

## Live-State Evidence

- Template ships no boundary: `https://app-templates.hercules.app/main.tar.gz` (branch `withzeusai/app-template@main`) — `grep -rniE "errorboundary|componentDidCatch|getDerivedStateFromError|error-boundary"` over the extracted tree returns nothing; `src/main.tsx` is a bare `createRoot().render(<App/>)`, `src/App.tsx` wraps `DefaultProviders`/routes with no boundary. The CUS-1202 app's `src/main.tsx`, `src/App.tsx`, and `src/components/providers/default.tsx` (read from the chat thread's tool calls) are byte-for-byte the same structure.
- The blank is a throw, not a missing auth branch: the app's pre-fix `src/pages/admin/_components/AdminLayout.tsx` renders a distinct UI for `AuthLoading` / `Unauthenticated` / non-admin / authorized — no code path returns nothing.
- Alternate ruled out (paused Convex deploy): prod DB `convex_deployment` for this website (`little-hyena-379`) shows `is_paused = f`; the live app `https://mikeryan.onhercules.app/` serves HTTP 200 with a real bundle. A paused deploy would not be fixed by a client-side error boundary, and the app-side boundary did resolve it.
- Recurring pattern (Linear CUS): 9 distinct prior blank-screen tickets; the same "uncaught render/query throw, no boundary" variant appears in CUS-1044 (admin portal black screen), CUS-1054 (app "crashes turning the screen blank after a second" when the Convex backend isn't running → `useQuery` throws), and CUS-429 (render error crashes to blank). CUS-164 (Urgent) is a near-twin: App Builder preview blank during `AuthLoading`. CUS-503 is a customer who "started with 10 credits to solve blank screen while loading."

## Adjacent call-site audit

- `src/App.tsx` (base) — fix-needed → wrapped.
- `.github/template-variants/managed-v1/src/App.tsx` — fix-needed (overrides base App.tsx, same gap) → wrapped; inherits `error-boundary.tsx` from base.
- `src/main.tsx` — none-needed: the boundary sits at the top of App's tree and catches every render throw beneath it.
- TanStack Start variant (`migrate/tanstack-start`, open PR #43) — intentionally-different: a separate, unmerged framework migration; TanStack Router has its own `errorComponent`/`defaultErrorComponent` mechanism. Out of scope here; flag for that PR to add a router-level default error component.
- Hercules monorepo `site/` app — none-needed: already has `app/_components/global-error.tsx` and `app/dashboard/(console)/_components/dashboard-error.tsx`.

## Care-skill compliance

No monorepo care skill applies: the change is in the app-template repo's `src`, not `packages/auth`, `packages/billing`, `worker-dispatcher`, or tenant-domain headers. The boundary wraps the auth providers but adds no auth/authorization logic, widens no security window, and sets no response header.

## Test plan

Verified against the template's own tooling (`pnpm install` clean):
- `tsc -b` — clean.
- `eslint` on the two changed base files in isolation — 0 warnings/errors (the 8 pre-existing `react-refresh` warnings are in original shadcn `ui/` files; count unchanged).
- `prettier --check` on all changed files — clean.
- `vite build` — clean (2116 modules transformed, bundle emitted).
- Manual: a component that throws under the boundary renders the recovery UI (not a blank page); "Reload page" reloads.

Draft: opening for review before it lands on the scaffold that seeds every generated app.
